### PR TITLE
It's not a kinda fix. just an update if we can avoid using  GENERATE_EXPORT_HEADER

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,6 @@ set(VERSION_PATCH "1")
 
 set(CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake ${CMAKE_MODULE_PATH})
 
-include(GenerateExportHeader)
 
 add_definitions(-Wall)
 option(WITHOUT_ASYNC "Fully Disable Async Ability, Only Sync mode" Off)

--- a/README.rst
+++ b/README.rst
@@ -10,32 +10,35 @@ updating here:
 
 This is zip, Im just forking this project for personal use and other guys who's still using old linux box.
 
-Im using Linux Fedora: 
-kernel-2.6.43.8-1.fc15.i686
-with:
-gcc-4.6.3-2.fc15.i686
-cmake-2.8.4-1.fc15.i686
-make-3.82-4.fc15.i686
-
-ev lib:
-libev-4.03-2.fc15.i686
-libev-devel-4.03-2.fc15.i686
-
-mozjs libs:
-js-devel-1.8.5-6.fc15.i686
+Im using Linux Fedora:: 
+    
+    kernel-2.6.43.8-1.fc15.i686
+    with:
+    gcc-4.6.3-2.fc15.i686
+    cmake-2.8.4-1.fc15.i686
+    make-3.82-4.fc15.i686
+    
+    ev lib:
+    libev-4.03-2.fc15.i686
+    libev-devel-4.03-2.fc15.i686
+    
+    mozjs libs:
+    js-devel-1.8.5-6.fc15.i686
 
 
 orig. update cannot work now on my box, with ERROR mesg:
 
 """
+
 CMake Error at lib/CMakeLists.txt:79 (GENERATE_EXPORT_HEADER):
   Unknown CMake command "GENERATE_EXPORT_HEADER".
 
 """
 
-it's involved by 
-commit 0af7cac3e3845d325a8a1e5a01476022dcd59f4d
-" add LWQQ_EXPORT for win dll export "
+it's involved by::
+    
+    commit 0af7cac3e3845d325a8a1e5a01476022dcd59f4d
+    " add LWQQ_EXPORT for win dll export "
 
 no use here for my using linux only, I dont have to upgrade my cmake utils.
 

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -70,15 +70,9 @@ if(WITH_LIBUV)
     set(LWQQ_OTHER_LIBS ${LWQQ_OTHER_LIBS} ${UV_LIBRARIES})
 endif()
 
-add_library(lwqq-static STATIC ${LWQQ_LIST} )
-set_target_properties(lwqq-static PROPERTIES 
-    OUTPUT_NAME lwqq
-    COMPILE_FLAGS -DLWQQ_STATIC_DEFINE
-    )
+add_library(lwqq-static STATIC ${LWQQ_LIST})
+set_target_properties(lwqq-static PROPERTIES OUTPUT_NAME lwqq)
 add_library(lwqq SHARED ${LWQQ_LIST} )
-GENERATE_EXPORT_HEADER(lwqq 
-    EXPORT_FILE_NAME ${PROJECT_BINARY_DIR}/lwqq_export.h
-    )
 
 target_link_libraries(lwqq
     ${SQLITE_LIBRARIES}


### PR DESCRIPTION
Please feel free to close this request, it's just for whomever also using old linux box and hit the error on this marco.

or we can try to avoid using this macro and instead the orig.s

Regards,
-zip
