### PR TITLE
fix use-after-free when disconnected

### DIFF
--- a/lib/vplist.c
+++ b/lib/vplist.c
@@ -68,10 +68,12 @@ void vp_do_repeat(vp_command cmd,void* retval)
 	}
 
 	vp_command* n = cmd.next;
+	vp_command* next = NULL;
 	while(n){
 		vp_start(n->data);
+		next = n->next;
 		n->dsph(n->func,&n->data,NULL);
-		n = n->next;
+		n = next;
 	}
 }
 


### PR DESCRIPTION
In vp_do_repeat(), when accessing n->next, n may have been freed, so this access may be illegal. 
On FreeBSD, freed memory is filled with 0x5a, so this causes pidgin segfaults when lwqq disconnects.
When disconnected, lwqq calls qq_close() -> qq_account_free() -> lwqq_client_free() -> vp_do_repeat(client->events->ext_clean, NULL). 
In vp_do_repeat(), it goes through client->events->ext_clean, and calls the function pointers in this list. One of the functions is lwqq_free_extension(), and it calls db_extension_free() at ext->remove(lc, ext) which calls vp_unlink(&lc->events->ext_clean, ext_->ext_clean). 
In vp_unlink(), it frees the vp_command which vp_do_repeat() is currently working on. So after returning from lwqq_free_extension(), n is freed, and accessing n->next is illegal.
The attached patch fixes this problem.
