### PR TITLE
fixed to build with mingw 4.8.2

### DIFF
--- a/lib/async_libuv.c
+++ b/lib/async_libuv.c
@@ -1,3 +1,5 @@
+#define NO_OLDNAMES
+//to get pass some problem about mkdir and macros
 #include "async_impl.h"
 #include "smemory.h"
 #include <uv.h>

--- a/src/cli.c
+++ b/src/cli.c
@@ -51,8 +51,11 @@ static CmdInfo cmdtab[] = {
     {"send", "s", send_f},
     {NULL, NULL, NULL},
 };
+
 #ifdef WIN32
-char *strtok_r(char *str, const char *delim, char **save)
+//no longer needed
+/*
+char *strtok_r(char *str, const char * delim, char ** save)
 {
     char *res, *last;
 
@@ -71,6 +74,7 @@ char *strtok_r(char *str, const char *delim, char **save)
     }
     return res;
 }
+*/
 const char* iconv(unsigned int from,unsigned int to,const char* str,size_t sz)
 {
 	static char buf[2048];


### PR DESCRIPTION
1. fix async_libuv.c with #define NO_OLDNAMES
2. fix cli.c with remove strtok_r
