### PR TITLE
Fix: 一直提示用户名或密码错误无法登录的问题

### DIFF
--- a/lib/login.c
+++ b/lib/login.c
@@ -129,7 +129,7 @@ static LwqqAsyncEvent* check_need_verify(LwqqClient *lc,const char* appid)
 	srand48(time(NULL));
 	double random = drand48();
 	snprintf(url, sizeof(url), WEBQQ_CHECK_HOST"/check?uin=%s&appid=%s&"
-			"js_ver=10037&js_type=0&%s%s&u1=http%%3A%%2F%%2Fweb2.qq.com%%2Floginproxy.html&r=%.16lf",
+			"js_ver=10112&js_type=0&%s%s&pt_tea=1&r=%.16lf",
 			lc->username, appid,
 			lc->login_sig?"login_sig=":"",
 			lc->login_sig?:"",


### PR DESCRIPTION
太神奇了！！！本来是在浏览器中跟代码想看看那个salt是什么情况的，发现了check这个请求URL和代码里的不太一样，简单修改一下居然成功登录。