### PR TITLE
avoid crash when JS_EncodeString return null

### DIFF
--- a/lib/login.c
+++ b/lib/login.c
@@ -611,6 +611,12 @@ static void login_stage_4(LwqqClient* lc,LwqqErrorCode* ec)
 	char* enc = lwqq_js_enc_pwd(lc->password, lc->vc->uin, lc->vc->str, js);
 	s_free(js_txt);
 	lwqq_js_close(js);
+	if(!enc) {
+		lwqq_log(LOG_ERROR, "Unknown error\n");
+		lc->stat = LWQQ_STATUS_LOGOUT;
+		vp_do_repeat(lc->events->login_complete, NULL);
+		return ;
+	}
 
 	/* Last: do real login */
 	LwqqAsyncEvent* ev = do_login(lc, enc, NULL);

--- a/lib/lwjs.c
+++ b/lib/lwjs.c
@@ -97,6 +97,7 @@ char* lwqq_js_hash(const char* uin,const char* ptwebqq,lwqq_js_t* js)
 	JS_CallFunctionName(js->context, global, "P", 2, argv, &res);
 
 	res_ = JS_EncodeString(js->context,JSVAL_TO_STRING(res));
+	if(!res_) return 0;
 	char* ret = strdup(res_);
 	JS_free(js->context,res_);
 
@@ -119,7 +120,9 @@ char* lwqq_js_enc_pwd(const char* pwd, const char* salt, const char* vcode, lwqq
 	argv[2] = STRING_TO_JSVAL(vcode_);
 	JS_CallFunctionName(js->context, global, "encryption", 3, argv, &res);
 
+	if(!res.s.payload.i32 && !res.s.payload.u32) return 0;
 	res_ = JS_EncodeString(js->context,JSVAL_TO_STRING(res));
+	if(!res_) return 0;
 	char* ret = strdup(res_);
 	JS_free(js->context,res_);
 


### PR DESCRIPTION
在我这里多次测试, 确信可以修复 https://github.com/xiehuc/pidgin-lwqq/issues/621

唯一不理解的是这部分:
```
if(!res.s.payload.i32 && !res.s.payload.u32) return 0;
```

在没有加这部分的情况下, 会 segfault 在 mozjs 里, 但是不添加 `if(!res_) return 0;` 却只是返回了一个空指针. 我只是抱着试试看的心态加了这个检测, 结果成功绕过问题了...